### PR TITLE
Add ExStatsD.Decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ end
 
 ### Decorators
 
-The decorators allow you to quickly and easily time function calls in your code. Simply replace `def` with `def_timed` for those functions you wish to time.
+The decorators allow you to quickly and easily time function calls in your code. Simply replace `def` with `deftimed` for those functions you wish to time.
 
 ```elixir
 defmodule MyModule.Data do
@@ -175,7 +175,7 @@ defmodule MyModule.Data do
 
   def init, do: :whatever
 
-  def_timed slow_function do
+  deftimed slow_function do
     # This is a suspect function we wish to time.
   end
 
@@ -194,17 +194,17 @@ definitions of the same arity unless specifically changed again. Other
 following functions of different name or arity will use the default.
 
 ```elixir
-def_timed init, do: nil # PREFIX.function_call.mymodule.data.init_0
+deftimed init, do: nil # PREFIX.function_call.mymodule.data.init_0
 
 @metric "trace.some_function"
-def_timed some_function(1), do: nil # PREFIX.trace.some_function
-def_timed some_function(2), do: nil # PREFIX.trace.some_function
+deftimed some_function(1), do: nil # PREFIX.trace.some_function
+deftimed some_function(2), do: nil # PREFIX.trace.some_function
 
 @metric "trace.some_function_catchall"
-def_timed some_function(x) when is_list(x), do: nil # PREFIX.trace.some_function_catchall
-def_timed some_function(x), do: nil # PREFIX.trace.some_function_catchall
+deftimed some_function(x) when is_list(x), do: nil # PREFIX.trace.some_function_catchall
+deftimed some_function(x), do: nil # PREFIX.trace.some_function_catchall
 
-def_timed some_function(x,y), do: nil # PREFIX.function_call.mymodule.data.some_function_2
+deftimed some_function(x,y), do: nil # PREFIX.function_call.mymodule.data.some_function_2
 ```
 
 You can set options using the `@metric_options` attribute. This follows the same rules as with the `@metric` example abobe.
@@ -213,7 +213,7 @@ Here we use Datadog's "tag" extension to StatD:
 
 ```elixir
 @metric_options [tags: ["basic"]]
-def_timed some_function(), do: nil
+deftimed some_function(), do: nil
 ```
 
 There are 2 global options available. Both will apply to all functions that follow it unless locally overridden.

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -17,6 +17,7 @@ defmodule ExStatsD do
   @default_host "127.0.0.1"
   @default_namespace nil
   @default_sink nil
+  @timing_stub 1.234
 
   # CLIENT
 
@@ -180,6 +181,8 @@ defmodule ExStatsD do
         {:sample, rate} ->
           {time, value} = :timer.tc(fun)
           amount = time / 1000.0
+          # We should hard code the amount when we are in test mode.
+          if (Mix.env == :test), do: amount = @timing_stub
           {metric, amount, :ms} |> transmit(options, rate)
           value
         _ ->
@@ -210,16 +213,27 @@ defmodule ExStatsD do
   end
 
   @doc """
-  (DogStatsD-only)
+  Time a function using a histogram metric (DogStatsD-only).
+
+  * `sample_rate`: Limit how often the metric is collected
+  * `tags`: Add tags to entry (DogStatsD-only)
+
+  It returns the result of the function call, making it suitable
+  for pipelining.
   """
   def histogram_timing(metric, fun, options \\ [sample_rate: 1, tags: []]) do
-    sampling options, fn(rate) ->
-      {time, value} = :timer.tc(fun)
-      amount = time / 1000.0
-      # We should hard code the amount when we are in test mode.
-      if (Mix.env == :test), do: amount = 1.234
-      {metric, amount, :h} |> transmit(options, rate)
-      value
+    sampling options, fn(decision) ->
+      case decision do
+        {:sample, rate} ->
+          {time, value} = :timer.tc(fun)
+          amount = time / 1000.0
+          # We should hard code the amount when we are in test mode.
+          if (Mix.env == :test), do: amount = @timing_stub
+          {metric, amount, :h} |> transmit(options, rate)
+          value
+        _ ->
+          fun.()
+      end
     end
   end
 

--- a/lib/ex_statsd/decorator.ex
+++ b/lib/ex_statsd/decorator.ex
@@ -7,7 +7,7 @@ defmodule ExStatsD.Decorator do
     end
   end
 
-  defmacro def_timed(head, body \\ nil) do
+  defmacro deftimed(head, body \\ nil) do
     {fun_name, args_ast} = Macro.decompose_call(head)
     arg_length = length(args_ast)
     quote do
@@ -70,8 +70,6 @@ defmodule ExStatsD.Decorator do
     else
       get_metric_options(module, function_id)
     end
-    # Let's just disable sample_rate as it makes *no* sense for this.
-    Keyword.delete(options, :sample_rate)
   end
 
   defp get_metric_options(module, function_id) do

--- a/test/lib/ex_statsd/decorator_test.exs
+++ b/test/lib/ex_statsd/decorator_test.exs
@@ -1,45 +1,47 @@
-defmodule DecoratorTest do
+defmodule ExStatsD.DecoratorTest do
   use ExUnit.Case, async: false
+
+  @stubbed_timing 1.234
 
   defmodule DecoratedModule do
     use ExStatsD.Decorator
 
-    def_timed simple do
+    deftimed simple do
       result = :simple
       result
     end
 
     @metric "custom_key"
-    def_timed custom_name, do: :custom_name
+    deftimed custom_name, do: :custom_name
 
-    def_timed custom_name_gone, do: :custom_name_gone
+    deftimed custom_name_gone, do: :custom_name_gone
 
     @metric "multi_0_or_1"
-    def_timed multi(0), do: 0
-    def_timed multi(1), do: 1
+    deftimed multi(0), do: 0
+    deftimed multi(1), do: 1
     @metric "multi_other"
-    def_timed multi(x), do: x
+    deftimed multi(x), do: x
 
     @metric_options [tags: [:mytag]]
-    def_timed with_options, do: :with_options
-    def_timed options_gone, do: :options_gone
+    deftimed with_options, do: :with_options
+    deftimed options_gone, do: :options_gone
 
     @metric_options [tags: [:options_fall_through]]
-    def_timed multi_options(0), do: 0
-    def_timed multi_options(1), do: 1
+    deftimed multi_options(0), do: 0
+    deftimed multi_options(1), do: 1
     @metric_options [tags: [:options_get_changed]]
-    def_timed multi_options(x), do: x
+    deftimed multi_options(x), do: x
 
     @use_histogram true
-    def_timed multi_attrs(x, y), do: {x, y}
-    def_timed multi_attrs(x, y, z), do: {x, y, z}
+    deftimed multi_attrs(x, y), do: {x, y}
+    deftimed multi_attrs(x, y, z), do: {x, y, z}
 
     @default_metric_options [tags: ["mine"]]
-    def_timed ignored_attr(_x), do: :ignored_attr
-    def_timed unbound_attr(_), do: :unbound_attr
+    deftimed ignored_attr(_x), do: :ignored_attr
+    deftimed unbound_attr(_), do: :unbound_attr
 
-    def_timed guarded(x) when is_list(x), do: {:ok, x}
-    def_timed guarded(_x), do: {:error, :not_a_list}
+    deftimed guarded(x) when is_list(x), do: {:ok, x}
+    deftimed guarded(_x), do: {:error, :not_a_list}
 
   end
 
@@ -51,7 +53,7 @@ defmodule DecoratorTest do
     {:ok, pid: pid}
   end
 
-  @prefix "test.function_call.elixir.decoratortest.decoratedmodule."
+  @prefix "test.function_call.elixir.exstatsd.decoratortest.decoratedmodule."
 
   test "basic wrapper with defaults" do
     assert DecoratedModule.simple === :simple


### PR DESCRIPTION
This builds on work by @JonGretar in #4, with modifications to go in-line with changes introduced in #1 and #2.

The only really notable change is cosmetic; the use of `deftimed` vs `def_timed`, to more closely match the convention used by other macros.
