### PR TITLE
add toplevel supervisor

### DIFF
--- a/lib/ex_statsd/application.ex
+++ b/lib/ex_statsd/application.ex
@@ -2,6 +2,6 @@ defmodule ExStatsD.Application do
   use Application
 
   def start(_type, _args) do
-    ExStatsD.start_link
+    ExStatsD.Supervisor.start_link([])
   end
 end

--- a/lib/ex_statsd/supervisor.ex
+++ b/lib/ex_statsd/supervisor.ex
@@ -1,0 +1,16 @@
+defmodule ExStatsD.Supervisor do
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    children = [
+      worker(ExStatsD, [], restart: :permanent)
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+
+end


### PR DESCRIPTION
exrm can't do hot upgrades when there is no top supervisor. see https://github.com/bitwalker/exrm/issues/183. this adds one :-)