### PR TITLE
Use application configuration for timing test mode instead of relying on Mix.env

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,6 @@
 use Mix.Config
 
-config :ex_statsd, sink: [], namespace: "test"
+config :ex_statsd,
+  sink: [],
+  namespace: "test",
+  test_mode: true

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -228,7 +228,8 @@ defmodule ExStatsD do
           {time, value} = :timer.tc(fun)
           amount = time / 1000.0
           # We should hard code the amount when we are in test mode.
-          if (Mix.env == :test), do: amount = @timing_stub
+          # But wait, this does not work with :exrm releases ! 
+          # if (Mix.env == :test), do: amount = @timing_stub
           {metric, amount, :h} |> transmit(options, rate)
           value
         _ ->

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -182,7 +182,7 @@ defmodule ExStatsD do
           {time, value} = :timer.tc(fun)
           amount = time / 1000.0
           # We should hard code the amount when we are in test mode.
-          if (Mix.env == :test), do: amount = @timing_stub
+          if Application.get_env(:ex_statsd, :test_mode, false), do: amount = @timing_stub
           {metric, amount, :ms} |> transmit(options, rate)
           value
         _ ->
@@ -228,8 +228,7 @@ defmodule ExStatsD do
           {time, value} = :timer.tc(fun)
           amount = time / 1000.0
           # We should hard code the amount when we are in test mode.
-          # But wait, this does not work with :exrm releases ! 
-          # if (Mix.env == :test), do: amount = @timing_stub
+          if Application.get_env(:ex_statsd, :test_mode, false), do: amount = @timing_stub
           {metric, amount, :h} |> transmit(options, rate)
           value
         _ ->


### PR DESCRIPTION
Hi!

I would be nice to use application configuration for timing test mode instead of relying on Mix.env. 

At least for users who are doing exrm releases where Mix module is not part of the release binary.