### PR TITLE
Support Elixir >= 1.0.0 < 2.0.0.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExStatsD.Mixfile do
   def project do
     [app: :ex_statsd,
      version: "0.5.1",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      package: package,
      deps: deps,
      # Documentation


### PR DESCRIPTION
This is a bit more flexible; is there any reason not to support Elixir 1.x? Otherwise I get a warning message when compiling ex_statsd on Elixir 1.1.