### PR TITLE
Fix sample rate reporting

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -273,7 +273,7 @@ defmodule ExStatsD do
 
   defp sample_rate_suffix(1), do: ""
   defp sample_rate_suffix(sample_rate) do
-    ["|@", :io_lib.format('~.2f', [1.0 / sample_rate])]
+    ["|@", :io_lib.format('~.2f', [sample_rate])]
   end
 
   defp tags_suffix([]), do: ""

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExStatsD.Mixfile do
 
   def project do
     [app: :ex_statsd,
-     version: "0.5.2",
+     version: "0.5.3",
      elixir: "~> 1.0",
      package: package,
      deps: deps,


### PR DESCRIPTION
According to https://github.com/b/statsd_spec and
http://docs.datadoghq.com/guides/dogstatsd/ the value behind the '@' should be
the actual rate, not the inverse.

I made a hotfix version bump - if you'd prefer I can revert that but a deploy soon would be great as we're relying on this in production.