### PR TITLE
Fixed stop call

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -37,7 +37,7 @@ defmodule ExStatsD do
   Stop the server.
   """
   def stop do
-    GenServer.call(__MODULE__, :stop)
+    GenServer.stop(__MODULE__)
   end
 
   @doc """

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -101,6 +101,11 @@ defmodule ExStatsDTest do
     assert value == 42
   end
 
+  test "stop", %{pid: pid} do
+    assert :ok == ExStatsD.stop
+    refute Process.alive?(pid)
+  end
+
   test "flush" do
     assert :ok == ExStatsD.flush
   end


### PR DESCRIPTION
As highlighted in #15, the library is missing tests and proper implementation for stopping the GenServer. This PR implements stopping the GenServer, with tests.
