### PR TITLE
Extended configuration to support runtime env vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The defaults are:
  * host: 127.0.0.1
  * port: 8125
  * namespace: nil
+ * tags: []
 
 The following are the basic metric types. Additional features are
 described in "Extensions," below.
@@ -150,6 +151,15 @@ option, eg:
 ```elixir
 ExStatsD.increment("cart.added", tags: ~w(foo bar))
 ```
+
+You can also configure default tags for all events, eg:
+
+```elixir
+config :ex_statsd, tags: ~w(env:staging app:web)
+```
+
+When using environment variable, separate tags by comma, eg: `export STATSD_TAGS=foo,bar,baz`
+
 
 #### Histograms
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ config :ex_statsd,
        namespace: "your-app"
 ```
 
+You can also use system environment variables like:
+
+```elixir
+use Mix.Config
+
+config :ex_statsd,
+       host: {:system, "STATSD_HOSTNAME"},
+       port: {:system, "STATSD_PORT", 8125} # you can also define default value
+```
+
 The defaults are:
 
  * host: 127.0.0.1

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -1,22 +1,11 @@
 defmodule ExStatsD do
   @moduledoc """
   Settings are taken from the `ex_statsd` application configuration.
-
-  The following are used to connect to your statsd server:
-
-   * `host`: The hostname or IP address (default: 127.0.0.1)
-   * `port`: The port number (default: 8125)
-
-  You can also provide an optional `namespace` to automatically nest all
-  stats.
+  See `ExStatsD.Config` for all the options.
   """
 
   use GenServer
 
-  @default_port 8125
-  @default_host "127.0.0.1"
-  @default_namespace nil
-  @default_sink nil
   @timing_stub 1.234
 
   # CLIENT
@@ -25,12 +14,7 @@ defmodule ExStatsD do
   Start the server.
   """
   def start_link(options \\ []) do
-    state = %{port:      Application.get_env(:ex_statsd, :port, @default_port),
-              host:      Application.get_env(:ex_statsd, :host, @default_host) |> parse_host,
-              namespace: Application.get_env(:ex_statsd, :namespace, @default_namespace),
-              sink:      Application.get_env(:ex_statsd, :sink, @default_sink),
-              socket:    nil}
-    GenServer.start_link(__MODULE__, state, [name: __MODULE__] ++ options)
+    GenServer.start_link(__MODULE__, ExStatsD.Config.generate, [name: __MODULE__] ++ options)
   end
 
   @doc """
@@ -48,13 +32,6 @@ defmodule ExStatsD do
     GenServer.call(__MODULE__, :flush)
   end
 
-  @doc false
-  defp parse_host(host) when is_binary(host) do
-    case host |> to_char_list |> :inet.parse_address do
-      {:error, _}    -> host |> String.to_atom
-      {:ok, address} -> address
-    end
-  end
 
   # API
 

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -266,14 +266,14 @@ defmodule ExStatsD do
   @doc false
   def handle_cast({:transmit, message, options, sample_rate}, %{sink: sink} = state) when is_list(sink) do
     tags = Keyword.get(options, :tags, [])
-    pkt = message |> packet(state.namespace, tags, sample_rate)
+    pkt = message |> packet(state.namespace, state.tags ++ tags, sample_rate)
     {:noreply, %{state | sink: [pkt | sink]}}
   end
 
   @doc false
   def handle_cast({:transmit, message, options, sample_rate}, state) do
     tags = Keyword.get(options, :tags, [])
-    pkt = message |> packet(state.namespace, tags, sample_rate)
+    pkt = message |> packet(state.namespace, state.tags ++ tags, sample_rate)
     {:ok, socket} = :gen_udp.open(0, [:binary])
     :gen_udp.send(socket, state.host, state.port, pkt)
     :gen_udp.close(socket)

--- a/lib/ex_statsd/config.ex
+++ b/lib/ex_statsd/config.ex
@@ -25,7 +25,7 @@ defmodule ExStatsD.Config do
   """
   def generate do
     %{
-      port:      get(:port, @default_port),
+      port:      get(:port, @default_port) |> parse_port,
       host:      get(:host, @default_host) |> parse_host,
       namespace: get(:namespace, @default_namespace),
       tags:      get(:tags, @default_tags) |> parse_tags,
@@ -53,6 +53,10 @@ defmodule ExStatsD.Config do
   defp finalize(value) do
     value
   end
+
+  defp parse_port(port) when is_integer(port), do: port
+  defp parse_port(port) when is_bitstring(port), do: port |> String.to_integer
+  defp parse_port(port) when is_nil(port), do: 8125
 
   defp parse_host(host) when is_binary(host) do
     case host |> to_char_list |> :inet.parse_address do

--- a/lib/ex_statsd/config.ex
+++ b/lib/ex_statsd/config.ex
@@ -1,0 +1,59 @@
+defmodule ExStatsD.Config do
+  @moduledoc """
+  Configuration parsing for statsd gen server, available options are:
+
+   * `host`: The hostname or IP address (default: 127.0.0.1)
+   * `port`: The port number (default: 8125)
+   * `namespace`: The namespace to prefix all the keys (default: nil)
+   * `sink` (default: nil)
+
+  You can also use environment variables on runtime, just specify the name
+  of variable in config like: `{:system, "ENV_VAR_NAME"}`. You can also pass
+  in default value, i.e.: `{:system, "ENV_VAR_NAME", "some default"}`.
+  """
+
+  @default_port 8125
+  @default_host "127.0.0.1"
+  @default_namespace nil
+  @default_sink nil
+
+  @doc """
+  Generates config map based on application configuration & environment variables.
+  """
+  def generate do
+    %{
+      port:      get(:port, @default_port),
+      host:      get(:host, @default_host) |> parse_host,
+      namespace: get(:namespace, @default_namespace),
+      sink:      get(:sink, @default_sink),
+      socket:    nil
+    }
+  end
+
+  defp get(option, default) do
+    Application.get_env(:ex_statsd, option, default)
+    |> finalize
+  end
+
+  defp finalize({:system, var}) do
+    System.get_env(var)
+  end
+
+  defp finalize({:system, var, default}) do
+    case System.get_env(var) do
+      nil -> default
+      val -> val
+    end
+  end
+
+  defp finalize(value) do
+    value
+  end
+
+  defp parse_host(host) when is_binary(host) do
+    case host |> to_char_list |> :inet.parse_address do
+      {:error, _}    -> host |> String.to_atom
+      {:ok, address} -> address
+    end
+  end
+end

--- a/lib/ex_statsd/config.ex
+++ b/lib/ex_statsd/config.ex
@@ -5,6 +5,8 @@ defmodule ExStatsD.Config do
    * `host`: The hostname or IP address (default: 127.0.0.1)
    * `port`: The port number (default: 8125)
    * `namespace`: The namespace to prefix all the keys (default: nil)
+   * `tags`: The tags to use in all requests - part of dogstatd extension (default: [])
+             When storing in env var, divide by commas.
    * `sink` (default: nil)
 
   You can also use environment variables on runtime, just specify the name
@@ -15,6 +17,7 @@ defmodule ExStatsD.Config do
   @default_port 8125
   @default_host "127.0.0.1"
   @default_namespace nil
+  @default_tags []
   @default_sink nil
 
   @doc """
@@ -25,6 +28,7 @@ defmodule ExStatsD.Config do
       port:      get(:port, @default_port),
       host:      get(:host, @default_host) |> parse_host,
       namespace: get(:namespace, @default_namespace),
+      tags:      get(:tags, @default_tags) |> parse_tags,
       sink:      get(:sink, @default_sink),
       socket:    nil
     }
@@ -56,4 +60,9 @@ defmodule ExStatsD.Config do
       {:ok, address} -> address
     end
   end
+
+  defp parse_tags(nil), do: []
+  defp parse_tags(""),  do: []
+  defp parse_tags(tags) when is_binary(tags), do: tags |> String.split(",")
+  defp parse_tags(tags), do: tags
 end

--- a/test/lib/ex_statsd/config_test.exs
+++ b/test/lib/ex_statsd/config_test.exs
@@ -1,7 +1,61 @@
 defmodule ExStatsD.ConfigTest do
   use ExUnit.Case
 
-  test "generate: return default values merged with ex_statsd app config" do
-    assert ExStatsD.Config.generate == %{port: 8125, host: {127, 0, 0, 1}, namespace: "test", sink: [], socket: nil}
+  test "generate: default values merged with ex_statsd app config" do
+    assert ExStatsD.Config.generate == %{
+      port: 8125,
+      host: {127, 0, 0, 1},
+      namespace: "test",
+      sink: [],
+      socket: nil,
+      tags: []
+    }
+  end
+
+  test "generate: when using system env vars" do
+    with_sys "foo,bar,baz", fn ->
+      with_app :tags, {:system, var}, fn ->
+        config = ExStatsD.Config.generate
+        assert config[:tags] == ~w(foo bar baz)
+      end
+    end
+  end
+
+  test "generate: when system var is empty" do
+    with_app :tags, {:system, var}, fn ->
+      config = ExStatsD.Config.generate
+      assert config[:tags] == []
+    end
+  end
+
+  test "generate: when system var is empty but default was given" do
+    with_app :tags, {:system, var, ~w(db perf)}, fn ->
+      config = ExStatsD.Config.generate
+      assert config[:tags] == ~w(db perf)
+    end
+  end
+
+  test "generate: when syustem var is present & default given" do
+    with_sys "foo,bar,baz", fn ->
+      with_app :tags, {:system, var, ~w(db perf)}, fn ->
+        config = ExStatsD.Config.generate
+        assert config[:tags] == ~w(foo bar baz)
+      end
+    end
+  end
+
+  defp var, do: "5689bec05b9b4acba45ddc2a0a61d693_exstasd_test"
+
+  defp with_sys(value, func) do
+    System.put_env(var, value)
+    func.()
+    System.delete_env(var)
+  end
+
+  defp with_app(name, val, func) do
+    old = Application.get_env(:ex_statsd, name)
+    Application.put_env(:ex_statsd, name, val)
+    func.()
+    Application.put_env(:ex_statsd, name, old)
   end
 end

--- a/test/lib/ex_statsd/config_test.exs
+++ b/test/lib/ex_statsd/config_test.exs
@@ -1,0 +1,7 @@
+defmodule ExStatsD.ConfigTest do
+  use ExUnit.Case
+
+  test "generate: return default values merged with ex_statsd app config" do
+    assert ExStatsD.Config.generate == %{port: 8125, host: {127, 0, 0, 1}, namespace: "test", sink: [], socket: nil}
+  end
+end


### PR DESCRIPTION
#1. Summary
- Extracted config module from gen server
- Added option to support fetching config from environment variables on runtime, with 
  `{:system, var_name, [default]}` struct.
- Added support for tags configuration
#2. Dynamic configuration

The reason for this change is to make deployment configuration easier.

At the moment the `config :ex_statsd, port: System.get_env("var_name")` would be fetched during compilation phase, i.e. on CI when building docker image. This is bad because, i.e. host/port can be dynamic in production & you most probably shouldn't store all your secrects on CI. Instead its better & often more desired to fetch the config during runtime for this kind of stuff (like in all other languages).

At the time of writing elixir & mix.config doesn't support anything like this out of the box & `{:system, var_name, [default]}` is convention used by community to support dynamic configuration.
#3. Tags configuration

Allow setting up tags in configuration, if they are present they will get added to all stats.
