### PR TITLE
Gwash3189/add additonal start options

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,31 @@ To achieve this you can manually start a `ExStatsD` instance.
 
 Of course, it's your own responsibility to supervise these servers.
 
+To do that, you can use [Supervisors](http://elixir-lang.org/docs/stable/elixir/Supervisor.html)
+
+```elixir
+defmodule StatsDSupervisor do
+  use Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    children = [
+      worker(ExStatsD, [[name: :first_name, namespace: "first.namespace"]], [id: "first_id"]),
+      worker(ExStatsD, [[name: :second_name, namespace: "second.namespace"]], [id: "second_id"])
+    ]
+
+    options = [
+      strategy: :one_for_one, name: StatsDSupervisor
+    ]
+
+    supervise(children, options)
+  end
+end
+```
+
 
 The items that can be overridden include
 * port

--- a/README.md
+++ b/README.md
@@ -219,6 +219,30 @@ There are 2 global options available. Both will apply to all functions that foll
  * `@default_metric_options`: Metric options to use unless overridden with `@metric_options`. Defaults to [].
  * `@use_histogram`: Send results using histograms instead of gauges. For use with Datadog's DogStatD. Defaults to false.
 
+## Starting your own ExStatsD Server
+
+There may be use cases where you need several `ExStatsD` instances. You may have several `namespaces` you need to send stats to, or maybe you have multiple statsd services you need to publish to.
+
+To achieve this you can manually start a `ExStatsD` instance.
+
+```elixir
+  {:ok, _first_pid} = ExStatsD.start_link([name: :first, namespace: "first.namespace"])
+
+  {:ok, _second_pid} = ExStatsD.start_link([name: :second, namespace: "second.namespace"])
+
+  ExStatsD.increment("the.thing", name: :first) # nil
+  ExStatsD.increment("another.thing", name: :second) # nil
+```
+
+Of course, it's your own responsibility to supervise these servers.
+
+
+The items that can be overridden include
+* port
+* host
+* namespace
+* sink
+
 ## License
 
 The MIT License (MIT)

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -25,12 +25,12 @@ defmodule ExStatsD do
   Start the server.
   """
   def start_link(options \\ []) do
-    state = %{port:      Application.get_env(:ex_statsd, :port, @default_port),
-              host:      Application.get_env(:ex_statsd, :host, @default_host) |> parse_host,
-              namespace: Application.get_env(:ex_statsd, :namespace, @default_namespace),
-              sink:      Application.get_env(:ex_statsd, :sink, @default_sink),
+    state = %{port:      Keyword.get(options, :port, default_config(:port, @default_port)),
+              host:      Keyword.get(options, :host, default_config(:host, @default_host)) |> parse_host,
+              namespace: Keyword.get(options, :namespace, default_config(:namespace, @default_namespace)),
+              sink:      Keyword.get(options, :sink, default_config(:sink, @default_sink)),
               socket:    nil}
-    GenServer.start_link(__MODULE__, state, [name: __MODULE__] ++ options)
+    GenServer.start_link(__MODULE__, state, Keyword.merge([name: __MODULE__], options))
   end
 
   @doc """
@@ -243,6 +243,10 @@ defmodule ExStatsD do
           fun.()
       end
     end
+  end
+
+  defp default_config(key, fallback) do
+    Application.get_env(:ex_statsd, key, fallback)
   end
 
   defp sampling(options, fun) when is_list(options) do

--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -24,6 +24,19 @@ defmodule ExStatsD do
   @doc """
   Start the server.
   """
+  @type statsd_port :: number
+  @type host :: String.t
+  @type sink :: String.t
+  @type name :: String.t
+  @type namespace :: String.t
+  @type options :: [
+    port: statsd_port,
+    host: host,
+    namespace: namespace,
+    sink: sink,
+    name: name
+  ]
+  @spec start_link(options) :: {:ok, pid}
   def start_link(options \\ []) do
     state = %{port:      Keyword.get(options, :port, default_config(:port, @default_port)),
               host:      Keyword.get(options, :host, default_config(:host, @default_host)) |> parse_host,
@@ -67,7 +80,7 @@ defmodule ExStatsD do
   It returns the amount given as its first argument, making it suitable
   for pipelining.
   """
-  def counter(amount, metric, options \\ default_options) do
+  def counter(amount, metric, options \\ default_options()) do
     sampling options, fn(decision) ->
       case decision do
         {:sample, rate} ->
@@ -88,7 +101,7 @@ defmodule ExStatsD do
   It returns the collection given as its first argument, making it suitable for
   pipelining.
   """
-  def count(collection, metric, options \\ default_options) do
+  def count(collection, metric, options \\ default_options()) do
     value = collection |> Enum.count
     sampling options, fn(decision) ->
       case decision do
@@ -109,7 +122,7 @@ defmodule ExStatsD do
 
   Returns `nil`.
   """
-  def increment(metric, options \\ default_options) do
+  def increment(metric, options \\ default_options()) do
     1 |> counter(metric, options)
     nil
   end
@@ -122,7 +135,7 @@ defmodule ExStatsD do
 
   Returns `nil`.
   """
-  def decrement(metric, options \\ default_options) do
+  def decrement(metric, options \\ default_options()) do
     -1 |> counter(metric, options)
     nil
   end
@@ -162,7 +175,7 @@ defmodule ExStatsD do
   It returns the value given as its first argument, making it suitable
   for pipelining.
   """
-  def timer(amount, metric, options \\ default_options) do
+  def timer(amount, metric, options \\ default_options()) do
     sampling options, fn(decision) ->
       case decision do
         {:sample, rate} ->
@@ -183,7 +196,7 @@ defmodule ExStatsD do
   It returns the result of the function call, making it suitable
   for pipelining.
   """
-  def timing(metric, fun, options \\ default_options) do
+  def timing(metric, fun, options \\ default_options()) do
     sampling options, fn(decision) ->
       case decision do
         {:sample, rate} ->
@@ -208,7 +221,7 @@ defmodule ExStatsD do
   It returns the value given as the first argument, making it suitable for
   pipelining.
   """
-  def histogram(amount, metric, options \\ default_options) do
+  def histogram(amount, metric, options \\ default_options()) do
     sampling options, fn(decision) ->
       case decision do
         {:sample, rate} ->
@@ -229,7 +242,7 @@ defmodule ExStatsD do
   It returns the result of the function call, making it suitable
   for pipelining.
   """
-  def histogram_timing(metric, fun, options \\ default_options) do
+  def histogram_timing(metric, fun, options \\ default_options()) do
     sampling options, fn(decision) ->
       case decision do
         {:sample, rate} ->

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -1,110 +1,154 @@
 defmodule ExStatsDTest do
   use ExUnit.Case
 
-  setup do
-    {:ok, pid} = ExStatsD.start_link
-    {:ok, pid: pid}
+  describe "with non-default options" do
+    test "override port through options" do
+      port = 8080
+      options = [port: port]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state.port == port
+    end
+
+    test "override host through options" do
+      host = "the_thing"
+      options = [host: host]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state.host == String.to_atom(host)
+    end
+
+    test "override namespace through options" do
+      namespace = "a_good_namespace"
+      options = [namespace: namespace]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state.namespace == namespace
+    end
+
+    test "override sink through options" do
+      sink = "everything_except_the_sink"
+      options = [sink: sink]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state.sink == sink
+    end
   end
 
-  test "count (in pipeline)" do
-    values = 1..100 |> ExStatsD.count("items")
-    assert sent == ["test.items:100|c"]
-    assert values == 1..100
+  describe "with default options" do
+    setup do
+      {:ok, pid} = ExStatsD.start_link
+      {:ok, pid: pid}
+    end
+
+    test "count (in pipeline)" do
+      values = 1..100 |> ExStatsD.count("items")
+      assert sent == ["test.items:100|c"]
+      assert values == 1..100
+    end
+
+    test "counter (in pipeline)" do
+      value = 3 |> ExStatsD.counter("items")
+      assert sent == ["test.items:3|c"]
+      assert value == 3
+    end
+
+    test "gauge (in pipeline)" do
+      value = 3 |> ExStatsD.gauge("items")
+      assert sent == ["test.items:3|g"]
+      assert value == 3
+    end
+
+    test "increment" do
+      ExStatsD.increment("events")
+      assert sent == ["test.events:1|c"]
+      ExStatsD.increment("events", sample_rate: 0.15)
+    end
+
+    test "increment with tags" do
+      ExStatsD.increment("events", tags: ["foo", "bar"])
+      assert sent == ["test.events:1|c|#foo,bar"]
+      ExStatsD.increment("events", sample_rate: 0.15)
+    end
+
+    test "decrement" do
+      ExStatsD.decrement("events")
+      assert sent == ["test.events:-1|c"]
+      ExStatsD.decrement("events", sample_rate: 0.15)
+    end
+
+    test "decrement with tags" do
+      ExStatsD.decrement("events", tags: ["foo", "bar"])
+      assert sent == ["test.events:-1|c|#foo,bar"]
+      ExStatsD.decrement("events", sample_rate: 0.15)
+    end
+
+    test "timing always calls" do
+      values = Enum.map 1..100, fn n -> ExStatsD.timing("foo.bar", fn -> n * 2 end, sample_rate: 0.01) end
+      assert values == Enum.map(1..100, fn n -> n * 2 end)
+    end
+
+    test "timer" do
+      value = 12 |> ExStatsD.timer("fun.elapsed")
+      assert sent == ["test.fun.elapsed:12|ms"]
+      assert value == 12
+    end
+
+    test "timer with tags" do
+      value = 12 |> ExStatsD.timer("fun.elapsed", tags: ["foo", "bar"])
+      assert sent == ["test.fun.elapsed:12|ms|#foo,bar"]
+      assert value == 12
+    end
+
+    test "gauge" do
+      value = 11 |> ExStatsD.gauge("fun.thing")
+      assert sent == ["test.fun.thing:11|g"]
+      assert value == 11
+    end
+
+    test "gauge with tags" do
+      value = 11 |> ExStatsD.gauge("fun.thing", tags: ["foo", "bar"])
+      assert sent == ["test.fun.thing:11|g|#foo,bar"]
+      assert value == 11
+    end
+
+    test "set" do
+      value = 1 |> ExStatsD.set("users.ids")
+      assert sent == ["test.users.ids:1|s"]
+      assert value == 1
+    end
+
+    test "set with tags" do
+      value = 1 |> ExStatsD.set("users.ids", tags: ["foo", "bar"])
+      assert sent == ["test.users.ids:1|s|#foo,bar"]
+      assert value == 1
+    end
+
+    test "histogram" do
+      value = 42 |> ExStatsD.histogram("histogram")
+      assert sent == ["test.histogram:42|h"]
+      assert value == 42
+    end
+
+    test "histogram with tags" do
+      value = 42 |> ExStatsD.histogram("histogram", tags: ["foo", "bar"])
+      assert sent == ["test.histogram:42|h|#foo,bar"]
+      assert value == 42
+    end
+
+    test "flush" do
+      assert :ok == ExStatsD.flush
+    end
   end
 
-  test "counter (in pipeline)" do
-    value = 3 |> ExStatsD.counter("items")
-    assert sent == ["test.items:3|c"]
-    assert value == 3
+  defp state(name \\ ExStatsD) do
+    :sys.get_state(name)
   end
 
-  test "gauge (in pipeline)" do
-    value = 3 |> ExStatsD.gauge("items")
-    assert sent == ["test.items:3|g"]
-    assert value == 3
-  end
-
-  test "increment" do
-    ExStatsD.increment("events")
-    assert sent == ["test.events:1|c"]
-    ExStatsD.increment("events", sample_rate: 0.15)
-  end
-
-  test "increment with tags" do
-    ExStatsD.increment("events", tags: ["foo", "bar"])
-    assert sent == ["test.events:1|c|#foo,bar"]
-    ExStatsD.increment("events", sample_rate: 0.15)
-  end
-
-  test "decrement" do
-    ExStatsD.decrement("events")
-    assert sent == ["test.events:-1|c"]
-    ExStatsD.decrement("events", sample_rate: 0.15)
-  end
-
-  test "decrement with tags" do
-    ExStatsD.decrement("events", tags: ["foo", "bar"])
-    assert sent == ["test.events:-1|c|#foo,bar"]
-    ExStatsD.decrement("events", sample_rate: 0.15)
-  end
-
-  test "timing always calls" do
-    values = Enum.map 1..100, fn n -> ExStatsD.timing("foo.bar", fn -> n * 2 end, sample_rate: 0.01) end
-    assert values == Enum.map(1..100, fn n -> n * 2 end)
-  end
-
-  test "timer" do
-    value = 12 |> ExStatsD.timer("fun.elapsed")
-    assert sent == ["test.fun.elapsed:12|ms"]
-    assert value == 12
-  end
-
-  test "timer with tags" do
-    value = 12 |> ExStatsD.timer("fun.elapsed", tags: ["foo", "bar"])
-    assert sent == ["test.fun.elapsed:12|ms|#foo,bar"]
-    assert value == 12
-  end
-
-  test "gauge" do
-    value = 11 |> ExStatsD.gauge("fun.thing")
-    assert sent == ["test.fun.thing:11|g"]
-    assert value == 11
-  end
-
-  test "gauge with tags" do
-    value = 11 |> ExStatsD.gauge("fun.thing", tags: ["foo", "bar"])
-    assert sent == ["test.fun.thing:11|g|#foo,bar"]
-    assert value == 11
-  end
-
-  test "set" do
-    value = 1 |> ExStatsD.set("users.ids")
-    assert sent == ["test.users.ids:1|s"]
-    assert value == 1
-  end
-
-  test "set with tags" do
-    value = 1 |> ExStatsD.set("users.ids", tags: ["foo", "bar"])
-    assert sent == ["test.users.ids:1|s|#foo,bar"]
-    assert value == 1
-  end
-
-  test "histogram" do
-    value = 42 |> ExStatsD.histogram("histogram")
-    assert sent == ["test.histogram:42|h"]
-    assert value == 42
-  end
-
-  test "histogram with tags" do
-    value = 42 |> ExStatsD.histogram("histogram", tags: ["foo", "bar"])
-    assert sent == ["test.histogram:42|h|#foo,bar"]
-    assert value == 42
-  end
-
-  test "flush" do
-    assert :ok == ExStatsD.flush
-  end
-
-  defp sent, do: :sys.get_state(ExStatsD).sink
+  defp sent, do: state.sink
 
 end

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -2,6 +2,15 @@ defmodule ExStatsDTest do
   use ExUnit.Case
 
   describe "with non-default options" do
+    test "override name through options" do
+      name = :dog_data
+      options = [name: name]
+
+      {:ok, pid} = ExStatsD.start_link(options)
+
+      assert Process.whereis(:dog_data) === pid
+    end
+
     test "override port through options" do
       port = 8080
       options = [port: port]
@@ -30,12 +39,21 @@ defmodule ExStatsDTest do
     end
 
     test "override sink through options" do
-      sink = "everything_except_the_sink"
+      sink = "everything_except_the_kitchen_sink"
       options = [sink: sink]
 
       {:ok, _pid} = ExStatsD.start_link(options)
 
       assert state.sink == sink
+    end
+
+    test "transmits data through correct server" do
+      options = [name: :the_name]
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      values = 1..100 |> ExStatsD.count("items", options)
+
+      assert sent(:the_name) == ["test.items:100|c"]
     end
   end
 
@@ -149,6 +167,6 @@ defmodule ExStatsDTest do
     :sys.get_state(name)
   end
 
-  defp sent, do: state.sink
+  defp sent(name \\ExStatsD), do: state(name).sink
 
 end


### PR DESCRIPTION
Hey! Awesome project here ❤️ 

I had a use case where i needed to submit stats to two different namespaces, so I thought i'd add the ability to do so. 

This PR lets the user
* Pass configuration options to `start_link/1`
 * These options override what's available in the `config` file. 
 * If an option is not available, then the `config` option is used.
 * If a `config` option is not available, then the default is used

Because you're now able to start multiple services with `start_link/1`, I've also added `name` to the list of things that can be overridden by the `options` list. 

Lastly, if a user has multiple services running, they can contact a specific service by adding `name: :the_name` to the options list. 