### PR TITLE
Allow for runtime configuration changes

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -61,6 +61,27 @@ defmodule ExStatsD do
     GenServer.call(name, :flush)
   end
 
+  @doc """
+  Update the StatsD configuration.
+
+  Changeable settings are `:port`, `:host`, `namespace` and `sink`.
+  """
+  @changeable_configuration [:port, :host, :namespace, :sink]
+  @type changeable_options :: [
+    port: statsd_port,
+    host: host,
+    namespace: namespace,
+    sink: sink
+  ]
+  @spec change_config(pid, options) :: :ok
+  def change_config(name \\__MODULE__, options) do
+    state = options
+            |> Enum.into(%{})
+            |> Map.take(@changeable_configuration)
+
+    GenServer.call(name, {:change_config, state})
+  end
+
   @doc false
   defp parse_host(host) when is_binary(host) do
     case host |> to_char_list |> :inet.parse_address do
@@ -326,5 +347,10 @@ defmodule ExStatsD do
   @doc false
   def handle_call(:flush, _from, state) do
     {:reply, :ok, state}
+  end
+
+  @doc false
+  def handle_call({:change_config, new_state}, _from, state) do
+    {:reply, :ok, Map.merge(state, new_state)}
   end
 end

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -51,7 +51,7 @@ defmodule ExStatsDTest do
       options = [name: :the_name]
       {:ok, _pid} = ExStatsD.start_link(options)
 
-      values = 1..100 |> ExStatsD.count("items", options)
+      1..100 |> ExStatsD.count("items", options)
 
       assert sent(:the_name) == ["test.items:100|c"]
     end

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -163,6 +163,33 @@ defmodule ExStatsDTest do
     end
   end
 
+  describe "runtime configuration change" do
+    setup do
+      {:ok, _pid} = ExStatsD.start_link
+      :ok
+    end
+
+    test "can change namespace" do
+      :ok = ExStatsD.change_config(namespace: "another_good_namespace")
+      assert state.namespace == "another_good_namespace"
+    end
+
+    test "can change port" do
+      :ok = ExStatsD.change_config(port: 8080)
+      assert state.port == 8080
+    end
+
+    test "can change host" do
+      :ok = ExStatsD.change_config(host: "the_thing")
+      assert state.host == "the_thing"
+    end
+
+    test "can overwrite sink" do
+      :ok = ExStatsD.change_config(sink: "everything_except_the_kitchen_sink")
+      assert state.sink == "everything_except_the_kitchen_sink"
+    end
+  end
+
   defp state(name \\ ExStatsD) do
     :sys.get_state(name)
   end


### PR DESCRIPTION
Hey there!

We would like to use `ExStatsD` in our app, but we need one capability that's not yet present in the current version: The ability to change the configuration (`host`, `port`, ..) at runtime.

I took a stab at adding this capability, since it was really straight forward. Also I'm happy to rework, if you think it should be done differently :-)

Looking forward to your feedback!