### PR TITLE
Change to newer :rand module

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -271,7 +271,7 @@ defmodule ExStatsD do
     end
   end
   defp sample(sample_rate, fun) do
-    case :random.uniform <= sample_rate do
+    case :rand.uniform <= sample_rate do
       true -> fun.({:sample, sample_rate})
       _ -> fun.(:no_sample)
     end

--- a/test/lib/ex_statsd/decorator_test.exs
+++ b/test/lib/ex_statsd/decorator_test.exs
@@ -48,8 +48,9 @@ defmodule ExStatsD.DecoratorTest do
   setup do
     {:ok, pid} = ExStatsD.start_link
     # Lets cheat for sampling here. Setting the seed like this should set the
-    # 3 next calls to :random.uniform as 0.01, 0.89 and 0.11
-    :random.seed(0, 0, 0)
+    # 3 next calls to :rand.uniform as
+    # 0.08510493518573344, 0.215260150460339, 0.7332665701643833
+    :rand.seed(:exs64, {0, 0, 6})
     {:ok, pid: pid}
   end
 


### PR DESCRIPTION
I ran into an issue where I was sending metrics from a newly spawned process, and the messages were never sent. I tracked this down to the `:random.uniform` call, which was not being seeded, and so returned the same sequence of numbers for the sampling check. This caused the messages to be never sent, since `:random.uniform was returning a value higher than the sample rate every time.

The `:random` module was replaced by `:rand` in Erlang 18, and `:rand` automatically seeds in a way that produces different numbers for each process, so I updated the calls to `:random` to be `:rand` instead.

see note at http://erlang.org/doc/man/random.html