### PR TITLE
Add ExStatsD.Config

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -11,6 +11,7 @@ defmodule ExStatsD do
   stats.
   """
 
+  alias ExStatsD.Config
   use GenServer
 
   @default_port 8125
@@ -38,10 +39,10 @@ defmodule ExStatsD do
   ]
   @spec start_link(options) :: {:ok, pid}
   def start_link(options \\ []) do
-    state = %{port:      Keyword.get(options, :port, default_config(:port, @default_port)),
-              host:      Keyword.get(options, :host, default_config(:host, @default_host)) |> parse_host,
-              namespace: Keyword.get(options, :namespace, default_config(:namespace, @default_namespace)),
-              sink:      Keyword.get(options, :sink, default_config(:sink, @default_sink)),
+    state = %{port:      Keyword.get(options, :port, Config.get(:port, @default_port)),
+              host:      Keyword.get(options, :host, Config.get(:host, @default_host)) |> parse_host,
+              namespace: Keyword.get(options, :namespace, Config.get(:namespace, @default_namespace)),
+              sink:      Keyword.get(options, :sink, Config.get(:sink, @default_sink)),
               socket:    nil}
     GenServer.start_link(__MODULE__, state, Keyword.merge([name: __MODULE__], options))
   end
@@ -254,13 +255,9 @@ defmodule ExStatsD do
           value
         _ ->
           fun.()
+        end
       end
     end
-  end
-
-  defp default_config(key, fallback) do
-    Application.get_env(:ex_statsd, key, fallback)
-  end
 
   defp default_options, do: [sample_rate: 1, tags: [], name: __MODULE__]
 

--- a/lib/ex_statsd/config.ex
+++ b/lib/ex_statsd/config.ex
@@ -1,0 +1,36 @@
+defmodule ExStatsD.Config do
+  @moduledoc """
+  This module handles fetching values from the config with some additional niceties
+  """
+
+  @doc """
+  Fetches a value from the config, or from the environment if {:system, "VAR"}
+  is provided.
+  An optional default value can be provided if desired.
+  ## Example
+  iex> {test_var, expected_value} = System.get_env |> Enum.take(1) |> List.first
+  ...> Application.put_env(:ex_statsd, :test_var, {:system, test_var})
+  ...> ^expected_value = #{__MODULE__}.get(:ex_statsd, :test_var)
+  ...> :ok
+  :ok
+  iex> Application.put_env(:ex_statsd, :test_var2, 1)
+  ...> 1 = #{__MODULE__}.get(:ex_statsd, :test_var2)
+  1
+  iex> :default = #{__MODULE__}.get(:ex_statsd, :missing_var, :default)
+  :default
+  """
+  @spec get(atom, term | nil) :: term
+  def get(key, default \\ nil) when is_atom(key) do
+    app = :ex_statsd
+
+    value = case Application.get_env(app, key) do
+      {:system, env_var} -> System.get_env(env_var)
+      value -> value
+    end
+
+    case value do
+      nil -> default
+      value -> value
+    end
+  end
+end

--- a/test/lib/ex_statsd/config_test.exs
+++ b/test/lib/ex_statsd/config_test.exs
@@ -1,0 +1,22 @@
+defmodule ExStatsD.ConfigTest do
+  alias ExStatsD.Config
+  use ExUnit.Case, async: false
+
+  test "reads application value" do
+    Application.put_env(:ex_statsd, :key, "APPLICATION_VALUE")
+    value = Config.get(:key)
+    assert value == "APPLICATION_VALUE"
+  end
+
+  test "reads application value with default" do
+    value = Config.get(:key, "DEFAULT_VALUE")
+    assert value == "APPLICATION_VALUE"
+  end
+
+  test "reads system value" do
+    System.put_env("SYSTEM_KEY", "SYSTEM_VALUE")
+    Application.put_env(:ex_statsd, :key, {:system, "SYSTEM_KEY"})
+    value = Config.get(:key)
+    assert value == "SYSTEM_VALUE"
+  end
+end

--- a/test/lib/ex_statsd/config_test.exs
+++ b/test/lib/ex_statsd/config_test.exs
@@ -6,11 +6,12 @@ defmodule ExStatsD.ConfigTest do
     Application.put_env(:ex_statsd, :key, "APPLICATION_VALUE")
     value = Config.get(:key)
     assert value == "APPLICATION_VALUE"
+    Application.delete_env(:ex_statsd, :key)
   end
 
   test "reads application value with default" do
     value = Config.get(:key, "DEFAULT_VALUE")
-    assert value == "APPLICATION_VALUE"
+    assert value == "DEFAULT_VALUE"
   end
 
   test "reads system value" do
@@ -18,5 +19,8 @@ defmodule ExStatsD.ConfigTest do
     Application.put_env(:ex_statsd, :key, {:system, "SYSTEM_KEY"})
     value = Config.get(:key)
     assert value == "SYSTEM_VALUE"
+
+    System.delete_env("SYSTEM_KEY")
+    Application.delete_env(:ex_statsd, :key)
   end
 end


### PR DESCRIPTION
So that we can read value from system env as well.

With the current way of reading the config it is very hard to load dynamic values from system env.

Currently all values are hardcoded in config files but hardcoding is a good practice in production because it leads to tying up application with infrastructure.

This will allow decoupling infrastructure setup from application code, only necessary thing is `sytem var`.

Suggestions are welcome, thanks.