### PR TITLE
Allow default tags to be sent with every metric in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ use Mix.Config
 config :ex_statsd,
        host: "your.statsd.host.com",
        port: 1234,
-       namespace: "your-app"
+       namespace: "your-app",
+       tags: ["env:#{Mix.env}"]
 ```
 
 The defaults are:
@@ -39,6 +40,7 @@ The defaults are:
  * host: 127.0.0.1
  * port: 8125
  * namespace: nil
+ * tags: []
 
 The following are the basic metric types. Additional features are
 described in "Extensions," below.

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -47,6 +47,15 @@ defmodule ExStatsDTest do
       assert state().sink == sink
     end
 
+    test "override root tags through options" do
+      tags = ["env:prod"]
+      options = [tags: tags]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state().tags == tags
+    end
+
     test "transmits data through correct server" do
       options = [name: :the_name]
       {:ok, _pid} = ExStatsD.start_link(options)


### PR DESCRIPTION
Allow an array of tags in the config that will be set for every metric sent. They can also be overwritten too. This is particularly helpful for app-level tags such as what environment it is.

If there's anything I need to do to clean this up, just let me know!