### PR TITLE
Parse port value coming from environment variables

### DIFF
--- a/lib/ex_statsd.ex
+++ b/lib/ex_statsd.ex
@@ -42,7 +42,7 @@ defmodule ExStatsD do
   ]
   @spec start_link(options) :: {:ok, pid}
   def start_link(options \\ []) do
-    state = %{port:      Keyword.get(options, :port,      Config.get(:port, @default_port)),
+    state = %{port:      Keyword.get(options, :port,      Config.get(:port, @default_port)) |> parse_port,
               host:      Keyword.get(options, :host,      Config.get(:host, @default_host)) |> parse_host,
               namespace: Keyword.get(options, :namespace, Config.get(:namespace, @default_namespace)),
               sink:      Keyword.get(options, :sink,      Config.get(:sink, @default_sink)),
@@ -73,6 +73,9 @@ defmodule ExStatsD do
       {:ok, address} -> address
     end
   end
+
+  defp parse_port(port) when is_integer(port), do: port
+  defp parse_port(port) when is_binary(port), do: String.to_integer(port)
 
   # API
 

--- a/lib/ex_statsd/config.ex
+++ b/lib/ex_statsd/config.ex
@@ -25,6 +25,7 @@ defmodule ExStatsD.Config do
 
     value = case Application.get_env(app, key) do
       {:system, env_var} -> System.get_env(env_var)
+      {:system, env_var, default} -> System.get_env(env_var) || default
       value -> value
     end
 

--- a/test/lib/ex_statsd/config_test.exs
+++ b/test/lib/ex_statsd/config_test.exs
@@ -23,4 +23,17 @@ defmodule ExStatsD.ConfigTest do
     System.delete_env("SYSTEM_KEY")
     Application.delete_env(:ex_statsd, :key)
   end
+
+  test "reads system value with default" do
+    System.put_env("SYSTEM_KEY_WITH_DEFAULT", "DEFINED_VALUE")
+    Application.put_env(:ex_statsd, :key, {:system, "SYSTEM_KEY_WITH_DEFAULT", "DEFAULT_VALUE"})
+    value = Config.get(:key)
+    assert value == "DEFINED_VALUE"
+
+    System.delete_env("SYSTEM_KEY_WITH_DEFAULT")
+    value = Config.get(:key)
+    assert value == "DEFAULT_VALUE"
+
+    Application.delete_env(:ex_statsd, :key)
+  end
 end

--- a/test/lib/ex_statsd_test.exs
+++ b/test/lib/ex_statsd_test.exs
@@ -20,6 +20,15 @@ defmodule ExStatsDTest do
       assert state().port == port
     end
 
+    test "convert port to number" do
+      port = "8080"
+      options = [port: port]
+
+      {:ok, _pid} = ExStatsD.start_link(options)
+
+      assert state().port == 8080
+    end
+
     test "override host through options" do
       host = "the_thing"
       options = [host: host]


### PR DESCRIPTION
Currently it's impossible to set port via `{:system, env_name}` tuple,
because it'll be parsed as a string, which is not accepted by `:gen_udp.connect/3`.

This commit converts port value to integer and also adds ability to
set default value for configuration options coming from envirionment variables.